### PR TITLE
Improved mounts configuration to make migrations from VCS visible

### DIFF
--- a/resources/platformsh/ibexa-commerce/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/3.3.x-dev/.platform.app.yaml
@@ -103,9 +103,9 @@ mounts:
     'public/var':
         source: local
         source_path: var
-    'src/Migrations/Ibexa':
+    'src/Migrations/Ibexa/migrations/references':
         source: local
-        source_path: migrations
+        source_path: references
     'config/graphql/types/ezplatform':
         source: local
         source_path: graphql_types

--- a/resources/platformsh/ibexa-commerce/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/3.3/.platform.app.yaml
@@ -103,9 +103,9 @@ mounts:
     'public/var':
         source: local
         source_path: var
-    'src/Migrations/Ibexa':
+    'src/Migrations/Ibexa/migrations/references':
         source: local
-        source_path: migrations
+        source_path: references
     'config/graphql/types/ezplatform':
         source: local
         source_path: graphql_types

--- a/resources/platformsh/ibexa-content/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/3.3.x-dev/.platform.app.yaml
@@ -103,9 +103,9 @@ mounts:
     'public/var':
         source: local
         source_path: var
-    'src/Migrations/Ibexa':
+    'src/Migrations/Ibexa/migrations/references':
         source: local
-        source_path: migrations
+        source_path: references
     'config/graphql/types/ezplatform':
         source: local
         source_path: graphql_types

--- a/resources/platformsh/ibexa-content/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/3.3/.platform.app.yaml
@@ -103,9 +103,9 @@ mounts:
     'public/var':
         source: local
         source_path: var
-    'src/Migrations/Ibexa':
+    'src/Migrations/Ibexa/migrations/references':
         source: local
-        source_path: migrations
+        source_path: references
     'config/graphql/types/ezplatform':
         source: local
         source_path: graphql_types

--- a/resources/platformsh/ibexa-experience/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/3.3.x-dev/.platform.app.yaml
@@ -103,9 +103,9 @@ mounts:
     'public/var':
         source: local
         source_path: var
-    'src/Migrations/Ibexa':
+    'src/Migrations/Ibexa/migrations/references':
         source: local
-        source_path: migrations
+        source_path: references
     'config/graphql/types/ezplatform':
         source: local
         source_path: graphql_types

--- a/resources/platformsh/ibexa-experience/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/3.3/.platform.app.yaml
@@ -103,9 +103,9 @@ mounts:
     'public/var':
         source: local
         source_path: var
-    'src/Migrations/Ibexa':
+    'src/Migrations/Ibexa/migrations/references':
         source: local
-        source_path: migrations
+        source_path: references
     'config/graphql/types/ezplatform':
         source: local
         source_path: graphql_types


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-799](https://issues.ibexa.co/browse/IBX-799)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3` 
| **BC breaks**                          | no

This PR introduces a more granular mount configuration so files delivered via VCS are visible but the `references` directory stays writable.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Asked for a review (ping `@ibexa/engineering`).
