### PR TITLE
Switched to current NodeJS LTS version

### DIFF
--- a/resources/platformsh/ibexa-commerce/4.0.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/4.0.x-dev/.platform.app.yaml
@@ -134,7 +134,7 @@ hooks:
         export NVM_DIR="$HOME/.nvm"
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         nvm current
-        nvm install 10.15.3
+        nvm install 14
 
         if [ -z "$COMPOSER_AUTH" ]; then
             echo "TIP: If you need to authenticate against Github/Gitlab/updates.ez.no, use COMPOSER_AUTH env variable"
@@ -149,7 +149,7 @@ hooks:
         set -e
 
         unset NPM_CONFIG_PREFIX
-        command -v nvm && nvm use 10.15.3
+        command -v nvm && nvm use 14
 
         if [ ! -f public/var/.platform.installed ]; then
             # Configure ElasticSearch mappings

--- a/resources/platformsh/ibexa-content/4.0.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/4.0.x-dev/.platform.app.yaml
@@ -134,7 +134,7 @@ hooks:
         export NVM_DIR="$HOME/.nvm"
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         nvm current
-        nvm install 10.15.3
+        nvm install 14
 
         if [ -z "$COMPOSER_AUTH" ]; then
             echo "TIP: If you need to authenticate against Github/Gitlab/updates.ez.no, use COMPOSER_AUTH env variable"
@@ -149,7 +149,7 @@ hooks:
         set -e
 
         unset NPM_CONFIG_PREFIX
-        command -v nvm && nvm use 10.15.3
+        command -v nvm && nvm use 14
 
         if [ ! -f public/var/.platform.installed ]; then
             # Configure ElasticSearch mappings

--- a/resources/platformsh/ibexa-experience/4.0.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/4.0.x-dev/.platform.app.yaml
@@ -134,7 +134,7 @@ hooks:
         export NVM_DIR="$HOME/.nvm"
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         nvm current
-        nvm install 10.15.3
+        nvm install 14
 
         if [ -z "$COMPOSER_AUTH" ]; then
             echo "TIP: If you need to authenticate against Github/Gitlab/updates.ez.no, use COMPOSER_AUTH env variable"
@@ -149,7 +149,7 @@ hooks:
         set -e
 
         unset NPM_CONFIG_PREFIX
-        command -v nvm && nvm use 10.15.3
+        command -v nvm && nvm use 14
 
         if [ ! -f public/var/.platform.installed ]; then
             # Configure ElasticSearch mappings

--- a/resources/platformsh/ibexa-oss/4.0.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/4.0.x-dev/.platform.app.yaml
@@ -128,7 +128,7 @@ hooks:
         export NVM_DIR="$HOME/.nvm"
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         nvm current
-        nvm install 10.15.3
+        nvm install 14
 
         if [ -z "$COMPOSER_AUTH" ]; then
             echo "TIP: If you need to authenticate against Github/Gitlab/updates.ez.no, use COMPOSER_AUTH env variable"
@@ -143,7 +143,7 @@ hooks:
         set -e
 
         unset NPM_CONFIG_PREFIX
-        command -v nvm && nvm use 10.15.3
+        command -v nvm && nvm use 14
 
         if [ ! -f public/var/.platform.installed ]; then
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-840](https://issues.ibexa.co/browse/IBX-840)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Updates the current version of NodeJS used on platform.sh instances to current LTS version

![image](https://user-images.githubusercontent.com/3183926/128325188-aec4dc38-e964-4c1e-b122-60af609b5b36.png)

This prevents issues:
```
Downloading and installing node v10.15.3...
    W: Downloading https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.xz...
https://console.platform.sh/ez-platform-sh-dev-account/v5p5smejfqk2u/master
    W: !!  error @ckeditor/ckeditor5-alignment@26.0.0: The engine "node" is incompatible with this module. Expected version ">=12.0.0". Got "10.15.3"
```

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
