### PR TITLE
[Doc] Added php at the beggining of command to clear http cache

### DIFF
--- a/resources/platformsh/ibexa-commerce/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/3.3.x-dev/.platform.app.yaml
@@ -187,10 +187,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-commerce/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/3.3/.platform.app.yaml
@@ -187,10 +187,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-content/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/3.3.x-dev/.platform.app.yaml
@@ -187,10 +187,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-content/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/3.3/.platform.app.yaml
@@ -187,10 +187,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-experience/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/3.3.x-dev/.platform.app.yaml
@@ -187,10 +187,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-experience/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/3.3/.platform.app.yaml
@@ -187,10 +187,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-oss/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/3.3.x-dev/.platform.app.yaml
@@ -178,10 +178,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.

--- a/resources/platformsh/ibexa-oss/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/3.3/.platform.app.yaml
@@ -178,10 +178,10 @@ hooks:
 
         # When using Varnish/Fastly, HttpCache is not cleared when clearing Symfony Cache folder above, you need to
         # clear cache yourself when for instance templates or config affecting responses change, for instance with:
-        ##bin/console fos:httpcache:invalidate:tag ez-all
+        ##php bin/console fos:httpcache:invalidate:tag ez-all
         # Depending on your VCL, buy default this would trigger a soft purge (expiry) and allow grace period, however
         # even so if your change only affected certain subset of content, ideally you should only clear specific tags:
-        ##bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
+        ##php bin/console fos:httpcache:invalidate:tag l44 c33 ct2 ...
 
     # Post deploy hook, like deploy but after being deployed and live, for deploy tasks we can do asynchronously
     # Tip: As this is running while web is running, and it's async, avoid doing anything like cache clearing that affects web requests here.


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0` 
| **BC breaks**                          | no

Just noticed this thing in the .platform.app.yaml we provide. All the commands that involves Symfony `bin/console` are preceded by `php` except the ones related to `foshttpcache`. 

I'm not creating a ticket for this as I don't see the need but let me know if you prefer me to do it. 

Also I'm doing pr against 1.0 branch. Let me know if that's ok for you .

ping @ibexa/engineering 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
