### PR TITLE
IBX-301 Changed cache clearing command to avoid cache issues on the deploy

### DIFF
--- a/resources/platformsh/common/3.3.x-dev/bin/platformsh_prestart_cacheclear.sh
+++ b/resources/platformsh/common/3.3.x-dev/bin/platformsh_prestart_cacheclear.sh
@@ -5,8 +5,8 @@
 set -e
 
 #date
-echo "removing var/cache/${APP_ENV-dev}/*.* to avoid Symfony container issues on interface changes"
-rm -Rf var/cache/${APP_ENV-dev}/*.*
+echo "removing var/cache/${APP_ENV-dev} to cache issues"
+rm -Rf var/cache/${APP_ENV-dev}
 #date
 echo "clearing application cache"
 php bin/console cache:clear

--- a/resources/platformsh/common/3.3.x-dev/bin/platformsh_prestart_cacheclear.sh
+++ b/resources/platformsh/common/3.3.x-dev/bin/platformsh_prestart_cacheclear.sh
@@ -5,8 +5,8 @@
 set -e
 
 #date
-echo "removing var/cache/${APP_ENV-dev} to cache issues"
-rm -Rf var/cache/${APP_ENV-dev}
+echo "removing var/cache/${APP_ENV-dev}/* to avoid Symfony container issues on interface changes"
+rm -Rf var/cache/${APP_ENV-dev}/*
 #date
 echo "clearing application cache"
 php bin/console cache:clear

--- a/resources/platformsh/common/3.3/bin/platformsh_prestart_cacheclear.sh
+++ b/resources/platformsh/common/3.3/bin/platformsh_prestart_cacheclear.sh
@@ -5,8 +5,8 @@
 set -e
 
 #date
-echo "removing var/cache/${APP_ENV-dev}/*.* to avoid Symfony container issues on interface changes"
-rm -Rf var/cache/${APP_ENV-dev}/*.*
+echo "removing var/cache/${APP_ENV-dev} to cache issues"
+rm -Rf var/cache/${APP_ENV-dev}
 #date
 echo "clearing application cache"
 php bin/console cache:clear

--- a/resources/platformsh/common/3.3/bin/platformsh_prestart_cacheclear.sh
+++ b/resources/platformsh/common/3.3/bin/platformsh_prestart_cacheclear.sh
@@ -5,8 +5,8 @@
 set -e
 
 #date
-echo "removing var/cache/${APP_ENV-dev} to cache issues"
-rm -Rf var/cache/${APP_ENV-dev}
+echo "removing var/cache/${APP_ENV-dev}/* to avoid Symfony container issues on interface changes"
+rm -Rf var/cache/${APP_ENV-dev}/*
 #date
 echo "clearing application cache"
 php bin/console cache:clear


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-301](https://issues.ibexa.co/browse/IBX-301)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

When the` cache:clear` command is executed it is making a check if cache "is fresh":
https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L132

When we execute `rm -rf var/cache/prod/*.*` beforehand cache:clear script is "tricked" into thinking that cache is fresh, as the request timestamp will be lower than Container File modification timestamp.
```
bulbo@bulboPC:~/www/experience-3.3$ rm -rf var/cache/prod/*.*
bulbo@bulboPC:~/www/experience-3.3$ php bin/console c:c --env=prod

 // Clearing the cache for the prod environment with debug                      
 // false                                                                       

$_SERVER['REQUEST_TIME']: ^ 1635942532
filemtime($containerFile): ^ 1635942536
time(): ^ 1635942536
```

This is due to that deleted files are firstly recreated (which will also affect `filemtime($containerFile)`) when `cache:clear` is called, and then Command logic executes.

To fix this, a whole `var/cache/prod` directory content should be removed.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
