### PR TITLE
IBX-3103: Bump default for Solr

### DIFF
--- a/resources/platformsh/common/3.3/.platform/services.yaml
+++ b/resources/platformsh/common/3.3/.platform/services.yaml
@@ -73,7 +73,7 @@ rediscache:
 
 # If you wish to use elasticsearch, uncomment this service and the corresponding relationship in .platform.app.yaml.
 #elasticsearch:
-#    type: elasticsearch:7.16
+#    type: elasticsearch:7.7
 #    disk: 512
 
 # Due to logic in app/config/env/platformsh.php, do not change the service name to something different than 'varnish'

--- a/resources/platformsh/common/3.3/.platform/services.yaml
+++ b/resources/platformsh/common/3.3/.platform/services.yaml
@@ -57,7 +57,7 @@ rediscache:
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:
-#    type: solr:8.11
+#    type: solr:8.6
 #    disk: 512
 #    configuration:
 #        configsets:

--- a/resources/platformsh/common/3.3/.platform/services.yaml
+++ b/resources/platformsh/common/3.3/.platform/services.yaml
@@ -57,7 +57,7 @@ rediscache:
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:
-#    type: solr:8.6
+#    type: solr:8.11
 #    disk: 512
 #    configuration:
 #        configsets:

--- a/resources/platformsh/common/3.3/.platform/services.yaml
+++ b/resources/platformsh/common/3.3/.platform/services.yaml
@@ -57,11 +57,11 @@ rediscache:
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:
-#    type: solr:7.7
+#    type: solr:8.11
 #    disk: 512
 #    configuration:
 #        configsets:
-#            mainconfig: !archive "configsets/solr6"
+#            mainconfig: !archive "configsets/solr8"
 #        cores:
 #            collection1:
 #                core_properties: |
@@ -73,7 +73,7 @@ rediscache:
 
 # If you wish to use elasticsearch, uncomment this service and the corresponding relationship in .platform.app.yaml.
 #elasticsearch:
-#    type: elasticsearch:7.7
+#    type: elasticsearch:7.16
 #    disk: 512
 
 # Due to logic in app/config/env/platformsh.php, do not change the service name to something different than 'varnish'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | ~[IBX-1699](https://issues.ibexa.co/browse/IBX-1699)~ (closed) / [IBX-3103](https://issues.ibexa.co/browse/IBX-3103)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | TBD

Upgrade default Solr install to 8.11 ~and ES install to 7.16.~ The log4j fix is in Solr 8.11.1 and ES 7.16.2. **This Solr upgrade is not supported by Solr yet, but they indicate they will eventually. Though they will not support the fixed ES.**
See: https://docs.platform.sh/configuration/services.html#type

pSH support say:
_Due to ES licensing change we are not able to support ES versions above 7.10. We do plan to support newer versions of Solr, but we don’t have any  ETA as of now._

No further updates to ES sounds like a problem for us!

**Update June 2022**, half a year later: pSH still do not support Solr 8.11. We need to give up for now. The furthest we can go is 8.6.

**2nd update June 2022**: pSH have added support for Solr 8.11! Reopened.
**NB:** It is only supported on Grid, not Dedicated, so far. Resolve this before committing anything. https://docs.platform.sh/add-services/solr.html#supported-versions

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] ~Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).~
- [ ] Verify Dedicated support before commit
- [ ] Make the same change to the other services.yaml files
- [ ] Asked for a review (ping `@ibexa/engineering`).
