### PR TITLE
Fixed composer check-cs/check-cs-changed command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor/
 composer.lock
 /components/
-.php_cs.cache
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         "fix-cs-changed": "php-cs-fixer fix --config=.php_cs -v --show-progress=dots $(git diff ${GIT_DIFF_BASE:-origin/main} --diff-filter=ACMR --name-only \"*.php\"|paste -sd ' ')",
         "test": "phpunit -c phpunit.xml",
         "phpstan": "phpstan analyse -c phpstan.neon",
-        "check-cs-changed": "php-cs-fixer fix --diff --config=.php_cs --dry-run -v --show-progress=dots $(git diff ${GIT_DIFF_BASE:-origin/main} --diff-filter=ACMR --name-only \"*.php\"|paste -sd ' ')",
-        "check-cs": "php-cs-fixer fix --diff --config=.php_cs --dry-run -v --show-progress=dots"
+        "check-cs-changed": "php-cs-fixer fix --diff --config=.php-cs-fixer.php --dry-run -v --show-progress=dots $(git diff ${GIT_DIFF_BASE:-origin/main} --diff-filter=ACMR --name-only \"*.php\"|paste -sd ' ')",
+        "check-cs": "php-cs-fixer fix --diff --config=.php-cs-fixer.php --dry-run -v --show-progress=dots"
     },
     "scripts-descriptions": {
         "fix-cs": "Fix Coding standard issues in current checkout.",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`+
| **BC breaks**                          | no

Fixed reference to non-existing .php_cs file in `composer check-cs`/`composer check-cs-changed` command

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
