### PR TITLE
IBX-2919: Added missing PHP sodium extension for OSS edition

### DIFF
--- a/resources/platformsh/ibexa-oss/3.3.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/3.3.x-dev/.platform.app.yaml
@@ -231,6 +231,7 @@ runtime:
         - readline
         - redis
         - igbinary
+        - sodium
         #- apcu
         #- name: 'blackfire'
         #  configuration:

--- a/resources/platformsh/ibexa-oss/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/3.3/.platform.app.yaml
@@ -231,6 +231,7 @@ runtime:
         - readline
         - redis
         - igbinary
+        - sodium
         #- apcu
         #- name: 'blackfire'
         #  configuration:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2919](https://issues.ibexa.co/browse/IBX-2919)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Added missing PHP sodium extension for OSS edition.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
