### PR TITLE
IBX-301: Fixed manual cache clearing

### DIFF
--- a/resources/platformsh/common/4.1.x-dev/bin/platformsh_prestart_cacheclear.sh
+++ b/resources/platformsh/common/4.1.x-dev/bin/platformsh_prestart_cacheclear.sh
@@ -5,8 +5,8 @@
 set -e
 
 #date
-echo "removing var/cache/${APP_ENV-dev}/*.* to avoid Symfony container issues on interface changes"
-rm -Rf var/cache/${APP_ENV-dev}/*.*
+echo "removing var/cache/${APP_ENV-dev}/* to avoid Symfony container issues on interface changes"
+rm -Rf var/cache/${APP_ENV-dev}/*
 #date
 echo "clearing application cache"
 php bin/console cache:clear

--- a/resources/platformsh/common/4.1/bin/platformsh_prestart_cacheclear.sh
+++ b/resources/platformsh/common/4.1/bin/platformsh_prestart_cacheclear.sh
@@ -5,8 +5,8 @@
 set -e
 
 #date
-echo "removing var/cache/${APP_ENV-dev}/*.* to avoid Symfony container issues on interface changes"
-rm -Rf var/cache/${APP_ENV-dev}/*.*
+echo "removing var/cache/${APP_ENV-dev}/* to avoid Symfony container issues on interface changes"
+rm -Rf var/cache/${APP_ENV-dev}/*
 #date
 echo "clearing application cache"
 php bin/console cache:clear

--- a/resources/platformsh/ibexa-commerce/4.1.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/4.1.x-dev/.platform.app.yaml
@@ -176,7 +176,7 @@ hooks:
 
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-commerce/4.1/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/4.1/.platform.app.yaml
@@ -176,7 +176,7 @@ hooks:
 
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-content/4.1.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/4.1.x-dev/.platform.app.yaml
@@ -176,7 +176,7 @@ hooks:
 
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-content/4.1/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/4.1/.platform.app.yaml
@@ -176,7 +176,7 @@ hooks:
 
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-experience/4.1.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/4.1.x-dev/.platform.app.yaml
@@ -176,7 +176,7 @@ hooks:
 
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-experience/4.1/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/4.1/.platform.app.yaml
@@ -176,7 +176,7 @@ hooks:
 
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-oss/4.1.x-dev/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/4.1.x-dev/.platform.app.yaml
@@ -167,7 +167,7 @@ hooks:
         if [ ! -f public/var/.platform.installed ]; then
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install

--- a/resources/platformsh/ibexa-oss/4.1/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/4.1/.platform.app.yaml
@@ -167,7 +167,7 @@ hooks:
         if [ ! -f public/var/.platform.installed ]; then
             # To workaround issues with p.sh Varnish we clear container cache & temporary set Symfony Proxy
             export SKIP_HTTPCACHE_PURGE="1"
-            rm -Rf var/cache/$APP_ENV/*.*
+            rm -Rf var/cache/$APP_ENV/*
             php bin/console cache:pool:clear cache.redis
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-301](https://issues.ibexa.co/browse/IBX-301)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.1` 
| **BC breaks**                          | no

Looks like the fix for bad cache cleared got lost on the way (https://github.com/ibexa/post-install/pull/22 - not sure how).

Description from the previous PR:

> When the cache:clear command is executed it is making a check if cache "is fresh":
> https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L132
> 
> When we execute rm -rf var/cache/prod/*.* beforehand cache:clear script is "tricked" into thinking that cache is fresh, as the request timestamp will be lower than Container File modification timestamp.
> 
> bulbo@bulboPC:~/www/experience-3.3$ rm -rf var/cache/prod/*.*
> bulbo@bulboPC:~/www/experience-3.3$ php bin/console c:c --env=prod
> 
>  // Clearing the cache for the prod environment with debug                      
>  // false                                                                       
> 
> $_SERVER['REQUEST_TIME']: ^ 1635942532
> filemtime($containerFile): ^ 1635942536
> time(): ^ 1635942536
> 
> This is due to that deleted files are firstly recreated (which will also affect filemtime($containerFile)) when cache:clear is called, and then Command logic executes.
> 
> To fix this, a whole var/cache/prod directory content should be removed.