### PR TITLE
Fixed composer plugin usage for phpstan/extension-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     },
     "require-dev": {
         "composer/composer": "^2.0.8",
-        "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "0.12.92",
         "phpstan/phpstan-phpunit": "^0.12.16",
         "phpstan/phpstan-webmozart-assert": "^0.12.7",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - phpstan-baseline.neon
 
 parameters:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR removes the `phpstan/extension-installer`, which relies upon Composer plugin functionality (which has to be otherwise specifically enabled per package, and we decided to rather include extension files manually).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
