### PR TITLE
Fixed PHPStan failing on PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     },
     "require-dev": {
         "composer/composer": "^2.0.8",
-        "phpstan/phpstan": "0.12.92",
-        "phpstan/phpstan-phpunit": "^0.12.16",
-        "phpstan/phpstan-webmozart-assert": "^0.12.7",
+        "phpstan/phpstan": "^1",
+        "phpstan/phpstan-phpunit": "^1",
+        "phpstan/phpstan-webmozart-assert": "^1",
         "symfony/dotenv": "^5.2",
         "symfony/filesystem": "^5.2",
         "symfony/phpunit-bridge": "^5.2",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,6 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: max
+    level: 8
     paths:
         - src


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.3`
| **BC breaks**                          | no

Updated PHPStan, which fixes the issue found in #57.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
