### PR TITLE
Update generate-solr-config.sh path

### DIFF
--- a/resources/platformsh/common/4.5.x-dev/.platform/services.yaml
+++ b/resources/platformsh/common/4.5.x-dev/.platform/services.yaml
@@ -53,7 +53,7 @@ rediscache:
 
 # If you wish to use solr, uncomment this service and the corresponding relationship in .platform.app.yaml.
 # Also, you need to generate the config using:
-# vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh
+# vendor/ibexa/solr/bin/generate-solr-config.sh
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`, `v4.5`, probably all v4.x
| **BC breaks**                          | no

The documenting comment about enabling Solr on Ibexa Cloud refers to old [ezsystems/ezplatform-solr-search-engine](https://github.com/ezsystems/ezplatform-solr-search-engine) instead of newer [ibexa/solr](https://github.com/ibexa/solr). The path led to a non-existent script.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
