### PR TITLE
IBX-5854: Allowed `ibexa-` prefixed cookies

### DIFF
--- a/resources/platformsh/common/4.5.x-dev/.platform/varnish.vcl
+++ b/resources/platformsh/common/4.5.x-dev/.platform/varnish.vcl
@@ -61,6 +61,7 @@ sub vcl_recv {
         set req.http.cookie = ";" + req.http.cookie;
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(eZSESSID[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa-[^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 

--- a/resources/platformsh/common/4.5/.platform/varnish.vcl
+++ b/resources/platformsh/common/4.5/.platform/varnish.vcl
@@ -61,6 +61,7 @@ sub vcl_recv {
         set req.http.cookie = ";" + req.http.cookie;
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(eZSESSID[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa-[^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5854](https://issues.ibexa.co/browse/IBX-5854)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5` - please update `x` accordingly
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->


As a part of unifying our backoffice cookies names - we should now allow passing all prefixed with `ibexa-` between varnish/fastly and backend.