### PR TITLE
IBX-7818: Fixed direct acces to index.php with long URL

### DIFF
--- a/resources/templates/apache2/vhost.template
+++ b/resources/templates/apache2/vhost.template
@@ -100,7 +100,7 @@
         RewriteRule ^/(css|js|fonts?)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
         # Prevent access to website with direct usage of index.php in URL
-        RewriteRule ^/([^/]+/)?index\.php([/?#]|$) - [R=404,L]
+        RewriteRule ^/([^/]+/)*?index\.php([/?#]|$) - [R=404,L]
 
         RewriteRule .* /index.php
     </IfModule>

--- a/resources/templates/nginx/ibexa_params.d/ibexa_rewrite_params
+++ b/resources/templates/nginx/ibexa_params.d/ibexa_rewrite_params
@@ -19,7 +19,7 @@ rewrite "^/build/(.*)" "/build/$1" break;
 rewrite "^/assets/(.*)" "/assets/$1" break;
 
 # Prevent access to website with direct usage of index.php in URL
-if ($request_uri ~ "^/([^/]+/)?index\.php([/?#]|$)") {
+if ($request_uri ~ "^/([^/]+/)*?index\.php([/?#]|$)") {
     return 404;
 }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7818](https://issues.ibexa.co/browse/IBX-7818)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Fixed an issue when index.php can be accessed directly if the URL is long and complexe enough

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (not sure which I should target since it's been in there for a very long time).
- [x] ~Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`). (N/A)~
- [x] Asked for a review.

@ibexa/engineering can you review this PR ? thank you