### PR TITLE
IBX-8506: Disabled display_errors in Cloud

### DIFF
--- a/resources/platformsh/ibexa-commerce/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/3.3/.platform.app.yaml
@@ -42,7 +42,10 @@ relationships:
 variables:
     php:
         # Example of setting php.ini config
-        #"display_errors": "On"
+        # Display of errors should be disabled in production.
+        display_errors: Off
+        display_startup_errors: Off
+
         memory_limit: 512M
         # The default OPcache configuration is not suited for Symfony applications
         opcache.memory_consumption: 256

--- a/resources/platformsh/ibexa-content/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-content/3.3/.platform.app.yaml
@@ -42,7 +42,10 @@ relationships:
 variables:
     php:
         # Example of setting php.ini config
-        #"display_errors": "On"
+        # Display of errors should be disabled in production.
+        display_errors: Off
+        display_startup_errors: Off
+
         memory_limit: 512M
         # The default OPcache configuration is not suited for Symfony applications
         opcache.memory_consumption: 256

--- a/resources/platformsh/ibexa-experience/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/3.3/.platform.app.yaml
@@ -42,7 +42,10 @@ relationships:
 variables:
     php:
         # Example of setting php.ini config
-        #"display_errors": "On"
+        # Display of errors should be disabled in production.
+        display_errors: Off
+        display_startup_errors: Off
+
         memory_limit: 512M
         # The default OPcache configuration is not suited for Symfony applications
         opcache.memory_consumption: 256

--- a/resources/platformsh/ibexa-oss/3.3/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/3.3/.platform.app.yaml
@@ -42,7 +42,10 @@ relationships:
 variables:
     php:
         # Example of setting php.ini config
-        #"display_errors": "On"
+        # Display of errors should be disabled in production.
+        display_errors: Off
+        display_startup_errors: Off
+
         memory_limit: 512M
         # The default OPcache configuration is not suited for Symfony applications
         opcache.memory_consumption: 256


### PR DESCRIPTION
| :ticket: Issue | IBX-8506 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/documentation-developer/pull/2423

#### Description:
The PHP config for Ibexa Cloud should default to not display errors in production. This is normally of no consequence as Symfony controls error handling, but in exceptional situations Symfony may fail and PHP's error handling take over. So to be on the safe side the default should be to not display errors.

#### For QA:
See Doc note below. And note that you will have to crash Symfony to reproduce the change.

#### Documentation:
See related doc PR (merged). Note also that these config files do not detect prod/dev mode, so display_errors will now by default be disabled regardless of mode, this should be noted in release notes.

#### Note
- [ ] Test the solution manually
- [ ] Provide automated test coverage
- [x] Confirm that target branch is set correctly
