### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.0'
+          - '8.3'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
@@ -42,9 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.0'
-          - '8.1'
+          - '8.3'
 
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +55,7 @@ jobs:
           extensions: pdo_sqlite, gd
           tools: cs2pr
 
-      - uses: "ramsey/composer-install@v1"
+      - uses: ramsey/composer-install@v3
         with:
           dependency-versions: "highest"
 

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
     },
     "require-dev": {
         "composer/composer": "^2.0.8",
+        "ibexa/code-style": "^1.0",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/phpstan-webmozart-assert": "^1",
-        "symfony/console": "^5.2",
-        "symfony/dotenv": "^5.2",
-        "symfony/finder": "^5.2",
-        "symfony/filesystem": "^5.2",
-        "symfony/phpunit-bridge": "^5.2",
-        "symfony/process": "^5.2",
-        "ibexa/code-style": "^1.0"
+        "symfony/console": "^6.4",
+        "symfony/dotenv": "^6.4",
+        "symfony/filesystem": "^6.4",
+        "symfony/finder": "^6.4",
+        "symfony/phpunit-bridge": "^6.4",
+        "symfony/process": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "composer/composer": "^2.0.8",
-        "ibexa/code-style": "^1.0",
+        "ibexa/code-style": "~2.0.0",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/phpstan-webmozart-assert": "^1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=8.3",
         "composer-plugin-api": "^2.0",
         "composer/semver": "^3.2"
     },

--- a/src/lib/Command/IbexaSetupCommand.php
+++ b/src/lib/Command/IbexaSetupCommand.php
@@ -27,8 +27,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class IbexaSetupCommand extends BaseCommand
 {
-    /** @var \Composer\Semver\VersionParser */
-    private $versionParser;
+    private VersionParser $versionParser;
 
     private const PSH_RESOURCES_PATH = __DIR__ . '/../../../resources/platformsh';
 
@@ -40,6 +39,9 @@ class IbexaSetupCommand extends BaseCommand
         ;
     }
 
+    /**
+     * @throws \Exception
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('platformsh')) {
@@ -108,6 +110,9 @@ class IbexaSetupCommand extends BaseCommand
         return Command::SUCCESS;
     }
 
+    /**
+     * @throws \Exception
+     */
     protected function getCommonFiles(string $product): Finder
     {
         $versionDir = $this->getVersionDirectory($product, self::PSH_RESOURCES_PATH . '/common');
@@ -122,6 +127,9 @@ class IbexaSetupCommand extends BaseCommand
         return $finder;
     }
 
+    /**
+     * @throws \Exception
+     */
     protected function getProductSpecificFiles(string $product, string $version): Finder
     {
         $productDir = str_replace('/', '-', $product);
@@ -198,7 +206,7 @@ class IbexaSetupCommand extends BaseCommand
 
     private function getVersionParser(): VersionParser
     {
-        if (null === $this->versionParser) {
+        if (!isset($this->versionParser)) {
             $this->versionParser = new VersionParser();
         }
 

--- a/src/lib/CommandProvider.php
+++ b/src/lib/CommandProvider.php
@@ -12,7 +12,7 @@ use Ibexa\PostInstall\Command\IbexaSetupCommand;
 
 class CommandProvider implements \Composer\Plugin\Capability\CommandProvider
 {
-    public function getCommands()
+    public function getCommands(): array
     {
         return [
             new IbexaSetupCommand(),

--- a/src/lib/PostInstall.php
+++ b/src/lib/PostInstall.php
@@ -32,7 +32,7 @@ class PostInstall implements PluginInterface, Capable
         $io->write('[Ibexa PostInstall tool] Uninstall', true, IOInterface::DEBUG);
     }
 
-    public function getCapabilities()
+    public function getCapabilities(): array
     {
         return [
             CommandProvider::class => SetupToolCommandProvider::class,


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready

| :ticket: Issue | IBX-8470 |
|----------------|-----------|


#### Description:

This PR bumps Symfony to v6 with optional codebase upgrades. The package doesn't depend on the other ibexa packages.

Key changes:

- [x] [Composer] Bumped Symfony packages requirements to ^6.4
- [x] [CS] Bumped Ibexa Code Style to ~2.0.0
- [x] [CI] Switched GHA CI job to run on PHP 8.3
- [x] Improved IbexaSetupCommand code quality
- [x] Added strict return types for Composer plugin extension points
- [x] [Composer] Bumped PHP requirement to >=8.3

#### QA:

Sanities in the form of regression tests.

#### Documentation:

No documentation required.