### PR TITLE
Updated outdated mentions of PHP 5

### DIFF
--- a/resources/templates/apache2/vhost.template
+++ b/resources/templates/apache2/vhost.template
@@ -26,8 +26,8 @@
             # See: https://wiki.apache.org/httpd/PHP-FPM#apache_httpd_2.4
 
             # For best performance, prefer socket use. This requires Linux, and that both Apache and PHP has access to
-            # the socket file `/var/run/php5-fpm.sock` via local file system and hence run on the same machine.
-            #SetHandler "proxy:unix:/var/run/php5-fpm.sock|fcgi://localhost/"
+            # the socket file `/var/run/php8.3-fpm.sock` via local file system and hence run on the same machine.
+            #SetHandler "proxy:unix:/var/run/php8.3-fpm.sock|fcgi://localhost/"
             # For TCP usage, if you're not on Linux, or Apache and PHP are on separate machines, instead use fcgi: form.
             # (Optionally hint php-fpm processes count using: https://wiki.apache.org/httpd/PHP-FPM#Proxy_via_handler)
             #SetHandler "proxy:fcgi://localhost/:9000"

--- a/resources/templates/apache2/vhost.template
+++ b/resources/templates/apache2/vhost.template
@@ -26,8 +26,8 @@
             # See: https://wiki.apache.org/httpd/PHP-FPM#apache_httpd_2.4
 
             # For best performance, prefer socket use. This requires Linux, and that both Apache and PHP has access to
-            # the socket file `/var/run/php/php8.3-fpm.sock` via local file system and hence run on the same machine.
-            #SetHandler "proxy:unix:/var/run/php/php8.3-fpm.sock|fcgi://localhost/"
+            # the socket file `/var/run/php/php-fpm.sock` via local file system and hence run on the same machine.
+            #SetHandler "proxy:unix:/var/run/php/php-fpm.sock|fcgi://localhost/"
             # For TCP usage, if you're not on Linux, or Apache and PHP are on separate machines, instead use fcgi: form.
             # (Optionally hint php-fpm processes count using: https://wiki.apache.org/httpd/PHP-FPM#Proxy_via_handler)
             #SetHandler "proxy:fcgi://localhost/:9000"

--- a/resources/templates/apache2/vhost.template
+++ b/resources/templates/apache2/vhost.template
@@ -26,8 +26,8 @@
             # See: https://wiki.apache.org/httpd/PHP-FPM#apache_httpd_2.4
 
             # For best performance, prefer socket use. This requires Linux, and that both Apache and PHP has access to
-            # the socket file `/var/run/php8.3-fpm.sock` via local file system and hence run on the same machine.
-            #SetHandler "proxy:unix:/var/run/php8.3-fpm.sock|fcgi://localhost/"
+            # the socket file `/var/run/php/php8.3-fpm.sock` via local file system and hence run on the same machine.
+            #SetHandler "proxy:unix:/var/run/php/php8.3-fpm.sock|fcgi://localhost/"
             # For TCP usage, if you're not on Linux, or Apache and PHP are on separate machines, instead use fcgi: form.
             # (Optionally hint php-fpm processes count using: https://wiki.apache.org/httpd/PHP-FPM#Proxy_via_handler)
             #SetHandler "proxy:fcgi://localhost/:9000"

--- a/resources/templates/nginx/vhost.template
+++ b/resources/templates/nginx/vhost.template
@@ -32,7 +32,7 @@ server {
             include ibexa_params.d/ibexa_fastcgi_params;
 
             # FPM socket
-            # Possible values : unix:/var/run/php5-fpm.sock or 127.0.0.1:9000
+            # Possible values : unix:/var/run/php8.3-fpm.sock or 127.0.0.1:9000
             fastcgi_pass %FASTCGI_PASS%;
 
             ## Ibexa DXP ENVIRONMENT variables, used for customizing index.php execution (not used by console commands)

--- a/resources/templates/nginx/vhost.template
+++ b/resources/templates/nginx/vhost.template
@@ -32,7 +32,7 @@ server {
             include ibexa_params.d/ibexa_fastcgi_params;
 
             # FPM socket
-            # Possible values : unix:/var/run/php/php8.3-fpm.sock or 127.0.0.1:9000
+            # Possible values : unix:/var/run/php/php-fpm.sock or 127.0.0.1:9000
             fastcgi_pass %FASTCGI_PASS%;
 
             ## Ibexa DXP ENVIRONMENT variables, used for customizing index.php execution (not used by console commands)

--- a/resources/templates/nginx/vhost.template
+++ b/resources/templates/nginx/vhost.template
@@ -32,7 +32,7 @@ server {
             include ibexa_params.d/ibexa_fastcgi_params;
 
             # FPM socket
-            # Possible values : unix:/var/run/php8.3-fpm.sock or 127.0.0.1:9000
+            # Possible values : unix:/var/run/php/php8.3-fpm.sock or 127.0.0.1:9000
             fastcgi_pass %FASTCGI_PASS%;
 
             ## Ibexa DXP ENVIRONMENT variables, used for customizing index.php execution (not used by console commands)


### PR DESCRIPTION

Removed the outdated mentions of PHP 5.

The socket name is taken from: https://php.watch/articles/php-8.3-install-upgrade-on-debian-ubuntu#sapis