### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,40 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      -   name: Add composer keys for private packagist
+          run: |
+            composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+            composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+          env:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+      -   uses: ramsey/composer-install@v3
+          with:
+            dependency-versions: highest
+
+      -   name: Run rector
+          run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-20.04"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require-dev": {
         "composer/composer": "^2.0.8",
         "ibexa/code-style": "~2.0.0",
+        "ibexa/rector": "~5.0.x-dev",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/phpstan-webmozart-assert": "^1",

--- a/rector.php
+++ b/rector.php
@@ -18,4 +18,7 @@ return RectorConfig::configure()
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+    ]);

--- a/src/lib/Command/IbexaSetupCommand.php
+++ b/src/lib/Command/IbexaSetupCommand.php
@@ -15,6 +15,7 @@ use Composer\Semver\Semver;
 use Composer\Semver\VersionParser;
 use Exception;
 use Ibexa\PostInstall\IbexaProductVersion;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -25,6 +26,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
+#[AsCommand(name: 'ibexa:setup', description: 'Runs post install configuration tool.')]
 class IbexaSetupCommand extends BaseCommand
 {
     private VersionParser $versionParser;
@@ -33,10 +35,12 @@ class IbexaSetupCommand extends BaseCommand
 
     protected function configure(): void
     {
-        $this->setName('ibexa:setup')
-             ->setDescription('Runs post install configuration tool.')
-             ->addOption('platformsh', null, InputOption::VALUE_NONE, 'Install Platform.sh config files')
-        ;
+        $this->addOption(
+            'platformsh',
+            null,
+            InputOption::VALUE_NONE,
+            'Install Platform.sh config files'
+        );
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [CLI] Replaced deprecated Command::{$defaultName, $defaultDescription} with the AsCommand attribute

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
