### PR TITLE
[5.0] Bump Solr, MariaDB, Redis & Elastic versions  for v5. Disable GQL schema generation

### DIFF
--- a/resources/platformsh/common/5.0/.platform/services.yaml
+++ b/resources/platformsh/common/5.0/.platform/services.yaml
@@ -24,7 +24,7 @@ mysqldb:
 
 # For use by Symfony Cache (used by Ibexa DXP SPI Persistence Cache)
 rediscache:
-    type: 'redis:5.0'
+    type: 'redis:7.2'
     # For cache you might need to increase the size of your plan if your installation has a sizeable amount of content.
     # Check with platform.sh staff if in doubt on this, and if it would make sense to configure larger redis size here.
     # size: L
@@ -37,14 +37,14 @@ rediscache:
 # If you wish to have a separate Redis instance for sessions, uncomment
 # this service and the corresponding relationship in .platform.app.yaml.
 #redissession:
-#    type: 'redis:5.0'
+#    type: 'redis:7.2'
 #    configuration:
 #        maxmemory_policy: allkeys-lru
 #
 # Alternatively if you have a requirement that sessions are persisted across server/redis restarts,
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
-#    type: redis-persistent:5.0
+#    type: redis-persistent:7.2
 # Disk size should be bigger than Redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
 # The memory given to Redis depends on your plan and "size: ". Adjust "disk: " accordingly.
 #    disk: 512

--- a/resources/platformsh/common/5.0/.platform/services.yaml
+++ b/resources/platformsh/common/5.0/.platform/services.yaml
@@ -57,7 +57,7 @@ rediscache:
 # Multi core setup is currently not supported on Platform.sh. Sharding does not work as the cores are
 # unable to reach each other
 #solrsearch:
-#    type: solr:7.7
+#    type: solr:8.11
 #    disk: 512
 #    configuration:
 #        configsets:

--- a/resources/platformsh/common/5.0/.platform/services.yaml
+++ b/resources/platformsh/common/5.0/.platform/services.yaml
@@ -4,7 +4,7 @@
 #     Reach out to platform.sh support to get help on this and insight into your disk/memory usage.
 
 mysqldb:
-    type: mariadb:10.4
+    type: mariadb:10.11
     disk: 1024
     configuration:
         schemas:

--- a/resources/platformsh/common/5.0/.platform/services.yaml
+++ b/resources/platformsh/common/5.0/.platform/services.yaml
@@ -73,7 +73,7 @@ rediscache:
 
 # If you wish to use elasticsearch, uncomment this service and the corresponding relationship in .platform.app.yaml.
 #elasticsearch:
-#    type: elasticsearch:7.7
+#    type: elasticsearch:7.17
 #    disk: 512
 
 # Due to logic in app/config/env/platformsh.php, do not change the service name to something different than 'varnish'

--- a/resources/platformsh/ibexa-commerce/5.0/.platform.app.yaml
+++ b/resources/platformsh/ibexa-commerce/5.0/.platform.app.yaml
@@ -184,7 +184,8 @@ hooks:
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install --no-interaction
             unset SKIP_HTTPCACHE_PURGE
-            php bin/console ibexa:graphql:generate-schema
+            # If you use GraphQL, uncomment this to generate the schema
+            ##php bin/console ibexa:graphql:generate-schema
 
             touch public/var/.platform.installed
         fi

--- a/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
+++ b/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
@@ -24,7 +24,7 @@ mysqldb:
 
 # For use by Symfony Cache (used by Ibexa DXP SPI Persistence Cache)
 rediscache:
-    type: 'redis:5.0'
+    type: 'redis:7.2'
     # For cache you might need to increase the size of your plan if your installation has a sizeable amount of content.
     # Check with platform.sh staff if in doubt on this, and if it would make sense to configure larger redis size here.
     # size: L
@@ -37,14 +37,14 @@ rediscache:
 # If you wish to have a separate Redis instance for sessions, uncomment
 # this service and the corresponding relationship in .platform.app.yaml.
 #redissession:
-#    type: 'redis:5.0'
+#    type: 'redis:7.2'
 #    configuration:
 #        maxmemory_policy: allkeys-lru
 #
 # Alternatively if you have a requirement that sessions are persisted across server/redis restarts,
 # have storage space to spare for this, and don't mind a bit slower instance type of redis
 #redissession:
-#    type: redis-persistent:5.0
+#    type: redis-persistent:7.2
 # Disk size should be bigger than Redis'  "maxmemory" setting due to https://redis.io/topics/persistence#log-rewriting.
 # The memory given to Redis depends on your plan and "size: ". Adjust "disk: " accordingly.
 #    disk: 512

--- a/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
+++ b/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
@@ -74,7 +74,7 @@ solrsearch:
 
 # If you wish to use elasticsearch, uncomment this service and the corresponding relationship in .platform.app.yaml.
 #elasticsearch:
-#    type: elasticsearch:7.7
+#    type: elasticsearch:7.17
 #    disk: 512
 
 # Due to logic in Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension, do not change the service name to something different from 'varnish'

--- a/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
+++ b/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
@@ -4,7 +4,7 @@
 #     Reach out to platform.sh support to get help on this and insight into your disk/memory usage.
 
 mysqldb:
-    type: mariadb:10.4
+    type: mariadb:10.11
     disk: 1024
     configuration:
         schemas:

--- a/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
+++ b/resources/platformsh/ibexa-commerce/5.0/.platform/services.yaml
@@ -58,7 +58,7 @@ rediscache:
 # unable to reach each other
 
 solrsearch:
-    type: solr:7.7
+    type: solr:8.11
     disk: 512
     configuration:
         configsets:

--- a/resources/platformsh/ibexa-experience/5.0/.platform.app.yaml
+++ b/resources/platformsh/ibexa-experience/5.0/.platform.app.yaml
@@ -184,7 +184,8 @@ hooks:
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install --no-interaction
             unset SKIP_HTTPCACHE_PURGE
-            php bin/console ibexa:graphql:generate-schema
+            # If you use GraphQL, uncomment this to generate GraphQL schema
+            ##php bin/console ibexa:graphql:generate-schema
 
             touch public/var/.platform.installed
         fi

--- a/resources/platformsh/ibexa-headless/5.0/.platform.app.yaml
+++ b/resources/platformsh/ibexa-headless/5.0/.platform.app.yaml
@@ -184,7 +184,8 @@ hooks:
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install --no-interaction
             unset SKIP_HTTPCACHE_PURGE
-            php bin/console ibexa:graphql:generate-schema
+            # If you use GraphQL, uncomment this to generate GraphQL schema
+            ##php bin/console ibexa:graphql:generate-schema
 
             touch public/var/.platform.installed
         fi

--- a/resources/platformsh/ibexa-oss/5.0/.platform.app.yaml
+++ b/resources/platformsh/ibexa-oss/5.0/.platform.app.yaml
@@ -178,7 +178,8 @@ hooks:
             sh bin/platformsh_prestart_cacheclear.sh
             SKIP_HTTPCACHE_PURGE="1" php -d memory_limit=-1 bin/console ibexa:install --no-interaction
             unset SKIP_HTTPCACHE_PURGE
-            php bin/console ibexa:graphql:generate-schema
+            # If you use GraphQL, uncomment this to generate GraphQL schema
+            ##php bin/console ibexa:graphql:generate-schema
 
             touch public/var/.platform.installed
         fi


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Bumped for v5:
- Solr from 7.7 to 8.11
- MariaDB from 10.4 to 10.11
- Redis from 5.0 to 7.2
- Elastic from 7.7 to 7.17

Varnish stays 6.0 (v5 supports 6.0 & 7.2).

Ref.
https://docs.platform.sh/add-services/solr.html#supported-versions
https://docs.platform.sh/add-services/mysql.html#supported-versions
https://docs.platform.sh/add-services/redis.html#supported-versions
https://docs.platform.sh/add-services/elasticsearch.html#supported-versions
https://docs.platform.sh/add-services/varnish.html#supported-versions

Disabled default GraphQL schema generation also.

TODO:
- [x] MariaDB 10.11
- [x] Redis 7.2
- [x] Elastic 7.17

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
