### PR TITLE
IBX-12173: Added Varnish 9 support for Platform.sh/Upsun

### DIFF
--- a/resources/platformsh/common/4.6/.platform/services.yaml
+++ b/resources/platformsh/common/4.6/.platform/services.yaml
@@ -83,3 +83,14 @@ varnish:
         vcl: !include
             type: string
             path: varnish.vcl
+
+# To use Varnish 9 instead of the default Varnish 6, comment out the "varnish" block above
+# and uncomment this one (note: service name must stay 'varnish', see comment above):
+#varnish:
+#    type: 'varnish:9.0'
+#    relationships:
+#        app: "app:http"
+#    configuration:
+#        vcl: !include
+#            type: string
+#            path: varnish9.vcl

--- a/resources/platformsh/common/4.6/.platform/varnish9.vcl
+++ b/resources/platformsh/common/4.6/.platform/varnish9.vcl
@@ -1,0 +1,322 @@
+// Varnish VCL for Platform.sh with:
+// - Varnish 9.0 or higher
+//   - Varnish xkey vmod (via varnish-modules package 0.28.0 or higher, or via Varnish Plus)
+// - eZ Platform 3.x or higher with ezplatform-http-cache (this) bundle
+//
+
+// Not applicable on Platform.sh:
+//vcl 4.1;
+//import std;
+import xkey;
+
+// Includes not available on Platform.sh, so inlining parameters.vlc:
+acl invalidators {
+    "127.0.0.1";
+    "192.168.0.0"/16;
+}
+
+// ACL for debuggers IP
+acl debuggers {
+    "127.0.0.1";
+    "192.168.0.0"/16;
+}
+
+// Called at the beginning of a request, after the complete request has been received
+sub vcl_recv {
+
+    // Set the backend
+    //set req.backend_hint = ezplatform;
+    // Platform.sh specific:
+    set req.backend_hint = app.backend();
+
+    // Add a Surrogate-Capability header to announce ESI support.
+    set req.http.Surrogate-Capability = "abc=ESI/1.0";
+
+    // Ensure that the Symfony Router generates URLs correctly with Varnish
+    if (req.http.X-Forwarded-Proto == "https" ) {
+        set req.http.X-Forwarded-Port = "443";
+    } else {
+        set req.http.X-Forwarded-Port = "80";
+    }
+
+    // Trigger cache purge if needed
+    call ez_purge;
+
+    // Don't cache requests other than GET and HEAD.
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+    }
+
+    // Don't cache Authenticate & Authorization
+    // You may remove this when using REST API with basic auth.
+    if (req.http.Authenticate || req.http.Authorization) {
+        if (client.ip ~ debuggers) {
+            set req.http.X-Debug = "Not Cached according to configuration (Authorization)";
+        }
+        return (hash);
+    }
+
+    // Remove all cookies besides Session ID, as JS tracker cookies and so will make the responses effectively un-cached
+    if (req.http.cookie) {
+        set req.http.cookie = ";" + req.http.cookie;
+        set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
+        set req.http.cookie = regsuball(req.http.cookie, ";(eZSESSID[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa-[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
+        set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
+
+        if (req.http.cookie == "") {
+            // If there are no more cookies, remove the header to get page cached.
+            unset req.http.cookie;
+        }
+    }
+
+    // Do a standard lookup on assets (these don't vary by user context hash)
+    // Note that file extension list below is not extensive, so consider completing it to fit your needs.
+    if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
+        return (hash);
+    }
+
+    // Sort the query string for cache normalization.
+    set req.url = std.querysort(req.url);
+
+    // Retrieve client user context hash and add it to the forwarded request.
+    call ez_user_context_hash;
+
+    // If it passes all these tests, do a lookup anyway.
+    return (hash);
+}
+
+// Called when the requested object has been retrieved from the backend
+sub vcl_backend_response {
+
+    if (bereq.http.accept ~ "application/vnd.fos.user-context-hash"
+        && beresp.status >= 500
+    ) {
+        return (abandon);
+    }
+
+    // Check for ESI acknowledgement and remove Surrogate-Control header
+    if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
+        unset beresp.http.Surrogate-Control;
+        set beresp.do_esi = true;
+    }
+
+    // Make Varnish keep all objects for up to 1 hour beyond their TTL, see vcl_hit for Request logic on this
+    // This will make Varnish to refresh objects in cache after 1 hour
+    // The total time object can be in cache is 70 minutes (grace + keep time)
+    set beresp.grace = 1h;
+    set beresp.keep = 10m;
+
+    // Compressing the content
+    if (beresp.http.Content-Type ~ "application/javascript"
+        || beresp.http.Content-Type ~ "application/vnd.ms-fontobject"
+        || beresp.http.Content-Type ~ "application/x-font-ttf"
+        || beresp.http.Content-Type ~ "image/svg+xml"
+        || beresp.http.Content-Type ~ "text/css"
+        || beresp.http.Content-Type ~ "text/plain"
+    ) {
+        set beresp.do_gzip = true;
+    }
+
+    // Modify xkey header to add translation suffix
+    if (beresp.http.xkey && beresp.http.x-lang) {
+        set beresp.http.xkey = beresp.http.xkey + " " + regsuball(beresp.http.xkey, "(\S+)", "\1" + beresp.http.x-lang);
+    }
+}
+
+// Handle purge
+// You may add FOSHttpCacheBundle tagging rules
+// See http://foshttpcache.readthedocs.org/en/latest/varnish-configuration.html#id4
+sub ez_purge {
+    // Retrieve purge token, needs to be here due to restart, match for PURGE method done within
+    call ez_invalidate_token;
+
+    # Adapted with acl from vendor/friendsofsymfony/http-cache/resources/config/varnish/fos_tags_xkey.vcl
+    if (req.method == "PURGEKEYS") {
+        call ez_purge_acl;
+
+        # If neither of the headers are provided we return 400 to simplify detecting wrong configuration
+        if (!req.http.xkey-purge && !req.http.xkey-softpurge) {
+            return (synth(400, "Neither header XKey-Purge or XKey-SoftPurge set"));
+        }
+
+        # Based on provided header invalidate (purge) and/or expire (softpurge) the tagged content
+        set req.http.n-gone = 0;
+        set req.http.n-softgone = 0;
+        if (req.http.xkey-purge) {
+            set req.http.n-gone = xkey.purge(req.http.xkey-purge);
+        }
+
+        if (req.http.xkey-softpurge) {
+            set req.http.n-softgone = xkey.softpurge(req.http.xkey-softpurge);
+        }
+
+        return (synth(200, "Purged "+req.http.n-gone+" objects, expired "+req.http.n-softgone+" objects"));
+    }
+
+    # Adapted with acl from vendor/friendsofsymfony/http-cache/resources/config/varnish/fos_purge.vcl
+    if (req.method == "PURGE") {
+        call ez_purge_acl;
+
+        return (purge);
+    }
+}
+
+sub ez_purge_acl {
+    if (req.http.x-invalidate-token) {
+        if (req.http.x-invalidate-token != req.http.x-backend-invalidate-token) {
+            return (synth(405, "Method not allowed"));
+        }
+    } else if  (!client.ip ~ invalidators) {
+        return (synth(405, "Method not allowed"));
+    }
+}
+
+// Sub-routine to get client user context hash, used to for being able to vary page cache on user rights.
+sub ez_user_context_hash {
+
+    // Prevent tampering attacks on the hash mechanism
+    if (req.restarts == 0
+        && (req.http.accept ~ "application/vnd.fos.user-context-hash"
+            || req.http.x-user-context-hash
+        )
+    ) {
+        return (synth(400));
+    }
+
+    if (req.restarts == 0 && (req.method == "GET" || req.method == "HEAD")) {
+        // Backup accept header, if set
+        if (req.http.accept) {
+            set req.http.x-fos-original-accept = req.http.accept;
+        }
+        set req.http.accept = "application/vnd.fos.user-context-hash";
+
+        // Backup original URL
+        set req.http.x-fos-original-url = req.url;
+        set req.url = "/_fos_user_context_hash";
+
+        // Force the lookup, the backend must tell not to cache or vary on all
+        // headers that are used to build the hash.
+        return (hash);
+    }
+
+    // Rebuild the original request which now has the hash.
+    if (req.restarts > 0
+        && req.http.accept == "application/vnd.fos.user-context-hash"
+    ) {
+        set req.url = req.http.x-fos-original-url;
+        unset req.http.x-fos-original-url;
+        if (req.http.x-fos-original-accept) {
+            set req.http.accept = req.http.x-fos-original-accept;
+            unset req.http.x-fos-original-accept;
+        } else {
+            // If accept header was not set in original request, remove the header here.
+            unset req.http.accept;
+        }
+
+        // Force the lookup, the backend must tell not to cache or vary on the
+        // user context hash to properly separate cached data.
+
+        return (hash);
+    }
+}
+
+// Sub-routine to get invalidate token.
+sub ez_invalidate_token {
+    // Prevent tampering attacks on the token mechanisms
+    if (req.restarts == 0
+        && (req.http.accept ~ "application/vnd.ezplatform.invalidate-token"
+            || req.http.x-backend-invalidate-token
+        )
+    ) {
+        return (synth(400));
+    }
+
+    if (req.restarts == 0 && (req.method == "PURGE" || req.method == "PURGEKEYS") && req.http.x-invalidate-token) {
+        set req.http.accept = "application/vnd.ezplatform.invalidate-token";
+
+        // Backup original http properties
+        set req.http.x-fos-token-url = req.url;
+        set req.http.x-fos-token-method = req.method;
+
+        set req.url = "/_ibexa_http_invalidatetoken";
+
+        // Force the lookup
+        return (hash);
+    }
+
+    // Rebuild the original request which now has the invalidate token.
+    if (req.restarts > 0
+        && req.http.accept == "application/vnd.ezplatform.invalidate-token"
+    ) {
+        set req.url = req.http.x-fos-token-url;
+        set req.method = req.http.x-fos-token-method;
+        unset req.http.x-fos-token-url;
+        unset req.http.x-fos-token-method;
+        unset req.http.accept;
+    }
+}
+
+sub vcl_deliver {
+    // On receiving the invalidate token response, copy the invalidate token to the original
+    // request and restart.
+    if (req.restarts == 0
+        && resp.http.content-type ~ "application/vnd.ezplatform.invalidate-token"
+    ) {
+        set req.http.x-backend-invalidate-token = resp.http.x-invalidate-token;
+
+        return (restart);
+    }
+
+    // On receiving the hash response, copy the hash header to the original
+    // request and restart.
+    if (req.restarts == 0
+        && resp.http.content-type ~ "application/vnd.fos.user-context-hash"
+    ) {
+        set req.http.x-user-context-hash = resp.http.x-user-context-hash;
+
+        return (restart);
+    }
+
+    // If we get here, this is a real response that gets sent to the client.
+
+    // Remove the vary on user context hash, this is nothing public. Keep all
+    // other vary headers.
+    if (resp.http.Vary ~ "X-User-Context-Hash") {
+        set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
+        set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
+        if (resp.http.Vary == "") {
+            unset resp.http.Vary;
+        }
+
+        // If we vary by user hash, we'll also adjust the cache control headers going out by default to avoid sending
+        // large ttl meant for Varnish to shared proxies and such. We assume only session cookie is left after vcl_recv.
+        if (req.http.cookie) {
+            // When in session where we vary by user hash we by default avoid caching this in shared proxies & browsers
+            // For browser cache with it revalidating against varnish, use for instance "private, no-cache" instead
+            set resp.http.cache-control = "private, no-cache, no-store, must-revalidate";
+        } else if (resp.http.cache-control ~ "public") {
+            // For non logged in users we allow caching on shared proxies (mobile network accelerators, planes, ...)
+            // But only for a short while, as there is no way to purge them
+            set resp.http.cache-control = "public, s-maxage=600, stale-while-revalidate=300, stale-if-error=300";
+        }
+    }
+
+    if (client.ip ~ debuggers) {
+        // Add X-Cache header if debugging is enabled
+        if (obj.hits > 0) {
+            set resp.http.X-Cache = "HIT";
+            set resp.http.X-Cache-Hits = obj.hits;
+            set resp.http.X-Cache-TTL = obj.ttl;
+        } else {
+            set resp.http.X-Cache = "MISS";
+        }
+    } else {
+        // Remove tag headers when delivering to non debug client
+        unset resp.http.xkey;
+        unset resp.http.x-lang;
+        // Sanity check to prevent ever exposing the hash to a non debug client.
+        unset resp.http.x-user-context-hash;
+    }
+}

--- a/resources/platformsh/common/4.6/.platform/varnish9.vcl
+++ b/resources/platformsh/common/4.6/.platform/varnish9.vcl
@@ -70,6 +70,13 @@ sub vcl_recv {
         }
     }
 
+    // Logged-in users must not be served stale content while the backend is healthy: drop their
+    // grace allowance so an expired object is refetched rather than delivered from the grace
+    // window. varnish5/6.vcl do this in vcl_hit with return (miss), which later versions do not support.
+    if (req.http.cookie && std.healthy(req.backend_hint)) {
+        set req.grace = 0s;
+    }
+
     // Do a standard lookup on assets (these don't vary by user context hash)
     // Note that file extension list below is not extensive, so consider completing it to fit your needs.
     if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
@@ -101,7 +108,7 @@ sub vcl_backend_response {
         set beresp.do_esi = true;
     }
 
-    // Make Varnish keep all objects for up to 1 hour beyond their TTL, see vcl_hit for Request logic on this
+    // Make Varnish keep all objects for up to 1 hour beyond their TTL, see vcl_recv for Request logic on this
     // This will make Varnish to refresh objects in cache after 1 hour
     // The total time object can be in cache is 70 minutes (grace + keep time)
     set beresp.grace = 1h;

--- a/resources/platformsh/common/4.6/.platform/varnish9.vcl
+++ b/resources/platformsh/common/4.6/.platform/varnish9.vcl
@@ -1,7 +1,6 @@
 // Varnish VCL for Platform.sh with:
 // - Varnish 9.0 or higher
 //   - Varnish xkey vmod (via varnish-modules package 0.28.0 or higher, or via Varnish Plus)
-// - eZ Platform 3.x or higher with ezplatform-http-cache (this) bundle
 //
 
 // Not applicable on Platform.sh:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-12173](https://ibexa.atlassian.net/browse/IBX-12173)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

> [!CAUTION]
>This PR cannot be merged up as-is. Talked to @barw4, and we agree to not merge this into 5.0 and up as it is deprecated and replaced by `ibexa/cloud` package

Adds `.platform/varnish9.vcl` and a commented-out `varnish:9.0` service block in
`.platform/services.yaml`, under `resources/platformsh/common/4.6/`. 


#### Related PRs:
- ibexa/http-cache#84 (source of the varnish9.vcl this uses)
- ibexa/docker#64 (matching opt-in Docker build)
- https://github.com/ibexa/cloud/pull/12
- https://github.com/ibexa/http-cache/pull/85

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`4.6`, matching the existing
      `resources/platformsh/common/4.6/` directory this feature extends).
- [ ] Ran PHP CS Fixer for new PHP code. (N/A — no PHP changes)
- [ ] Asked for a review (ping `@ibexa/engineering`).


[IBX-12173]: https://ibexa.atlassian.net/browse/IBX-12173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ